### PR TITLE
Don't set a default output file

### DIFF
--- a/src/pqg/__main__.py
+++ b/src/pqg/__main__.py
@@ -53,8 +53,8 @@ def main() -> None:
 
         print()
 
-      print(query_pool.statistics())
+  print(query_pool.statistics())
 
+  if arguments.output_file:
     query_pool.save(arguments.output_file)
-
     print(f'\nQueries written to {arguments.output_file}')

--- a/src/pqg/arguments.py
+++ b/src/pqg/arguments.py
@@ -91,7 +91,7 @@ class Arguments:
   max_selection_conditions: int
   multi_line: bool
   num_queries: int
-  output_file: str
+  output_file: t.Optional[str]
   projection_probability: float
   schema: str
   selection_probability: float
@@ -183,7 +183,6 @@ class Arguments:
       '--output-file',
       type=str,
       required=False,
-      default='queries.txt',
       help='The name of the file to write the results to',
     )
 


### PR DESCRIPTION
We're currently setting a default output file, which means queries will always get written to a file without allowing the user to choose this.